### PR TITLE
Improve some parser failure messages

### DIFF
--- a/src/Combine.elm
+++ b/src/Combine.elm
@@ -1157,7 +1157,7 @@ brackets =
 -}
 whitespace : Parser s String
 whitespace =
-    regex "\\s*" |> onerror "whitespace"
+    regex "\\s*" |> onerror "optional whitespace"
 
 
 {-| Parse one or more whitespace characters.

--- a/src/Combine/Char.elm
+++ b/src/Combine/Char.elm
@@ -119,28 +119,28 @@ noneOf cs =
 -}
 space : Parser s Char
 space =
-    satisfy ((==) ' ') |> onerror "expected space"
+    satisfy ((==) ' ') |> onerror "expected a space"
 
 
 {-| Parse a `\t` character.
 -}
 tab : Parser s Char
 tab =
-    satisfy ((==) '\t') |> onerror "expected tab"
+    satisfy ((==) '\t') |> onerror "expected a tab"
 
 
 {-| Parse a `\n` character.
 -}
 newline : Parser s Char
 newline =
-    satisfy ((==) '\n') |> onerror "expected newline"
+    satisfy ((==) '\n') |> onerror "expected a newline"
 
 
 {-| Parse a `\r\n` sequence, returning a `\n` character.
 -}
 crlf : Parser s Char
 crlf =
-    string "\u{000D}\n" |> onsuccess '\n' |> onerror "expected crlf"
+    string "\u{000D}\n" |> onsuccess '\n' |> onerror "expected CRLF"
 
 
 {-| Parse an end of line character or sequence, returning a `\n` character.

--- a/src/Combine/Num.elm
+++ b/src/Combine/Num.elm
@@ -45,7 +45,7 @@ int =
     regex "-?(?:0|[1-9]\\d*)"
         |> map String.toInt
         |> andThen unwrap
-        |> onerror "expected an float"
+        |> onerror "expected an int"
 
 
 {-| Parse a float.
@@ -55,7 +55,7 @@ float =
     regex "-?(?:0|[1-9]\\d*)\\.\\d+"
         |> map String.toFloat
         |> andThen unwrap
-        |> onerror "expected an float"
+        |> onerror "expected a float"
 
 
 unwrap : Maybe v -> Parser s v


### PR DESCRIPTION
Thanks for a great port to 0.19! Super useful. 
Couldn't file an issue so made a small PR directly instead:

### Fixes made
 * Most importantly: `Int` was failing _with expected an Float_
 * Also, _expected whitespace_ for `\s*` was perhaps misleading, so changed to _expected optional whitespace_ (even though this will probably never fail :grin:)
 * Others fixed for better consistency / English